### PR TITLE
Fix Surge-XT

### DIFF
--- a/pkgs/applications/audio/surge-XT/default.nix
+++ b/pkgs/applications/audio/surge-XT/default.nix
@@ -1,23 +1,41 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, cairo, libxkbcommon
-, xcbutilcursor, xcbutilkeysyms, xcbutil, libXrandr, libXinerama, libXcursor
-, alsa-lib, libjack2, lv2 }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, alsa-lib
+, freetype
+, libjack2
+, lv2
+, libX11
+, libXcursor
+, libXext
+, libXinerama
+, libXrandr
+}:
 
 let
-  juce-lv2 = stdenv.mkDerivation rec {
-    name = "JUCE-lv2";
+  juce-lv2 = stdenv.mkDerivation {
+    pname = "juce-lv2";
+    version = "unstable-2021-10-21";
 
+    # lv2 branch
     src = fetchFromGitHub {
       owner = "lv2-porting-project";
       repo = "JUCE";
       rev = "f7eb3b4681c1fb4735bcd388d7a5ed10ccd24aba";
       sha256 = "sha256-jwWDB0XXaKkHJDNOSnhV4tDd+2lt61Qp8gFwXDuY63c=";
     };
+
+    dontConfigure = true;
+    dontBuild = true;
+
     installPhase = ''
       cp -r . $out
     '';
   };
-
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "surge-XT";
   version = "unstable-2021-12-07";
 
@@ -25,46 +43,43 @@ in stdenv.mkDerivation rec {
     owner = "surge-synthesizer";
     repo = "surge";
     rev = "c61ae7f2e1e8ecfc646030618bd3c4439d3ddf79";
-    sha256 = "sha256-R8qGDxJffYddeDjEtoIe0gB+WMwCEyvoAAhaxPyM/SA=";
     fetchSubmodules = true;
+    sha256 = "sha256-R8qGDxJffYddeDjEtoIe0gB+WMwCEyvoAAhaxPyM/SA=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
   buildInputs = [
-    cairo
-    libxkbcommon
-    xcbutilcursor
-    xcbutilkeysyms
-    xcbutil
-    libXrandr
-    libXinerama
-    libXcursor
     alsa-lib
+    freetype
     libjack2
     lv2
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
   ];
 
   cmakeFlags = [
-    "-Bbuild"
-    "-DJUCE_SUPPORTS_LV2=True"
+    "-DJUCE_SUPPORTS_LV2=ON"
     "-DSURGE_JUCE_PATH=${juce-lv2}"
   ];
 
-  enableParallelBuilding = true;
-
-  buildPhase = ''
-    cmake --build build --target surge-xt_LV2 surge-fx_LV2 surge-xt_Packaged surge-fx_Packaged --parallel
-  '';
-
-  installPhase = ''
-    cmake --install build
-  '';
-
-  doInstallCheck = false;
+  # JUCE dlopen's these at runtime, crashes without them
+  NIX_LDFLAGS = (toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ]);
 
   meta = with lib; {
-    description =
-      "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";
+    description = "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";
     homepage = "https://surge-synthesizer.github.io";
     license = licenses.gpl3;
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
###### Motivation for this change
Fixes for https://github.com/NixOS/nixpkgs/pull/149487

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
